### PR TITLE
Grammar fix in comment

### DIFF
--- a/core/java/android/os/Debug.java
+++ b/core/java/android/os/Debug.java
@@ -105,7 +105,7 @@ public final class Debug
 
     /**
      * This class is used to retrieved various statistics about the memory mappings for this
-     * process. The returns info broken down by dalvik, native, and other. All results are in kB.
+     * process. The returned info is broken down by dalvik, native, and other. All results are in kB.
      */
     public static class MemoryInfo implements Parcelable {
         /** The proportional set size for dalvik. */


### PR DESCRIPTION
I was confused by the grammar in the class introduction at http://developer.android.com/reference/android/os/Debug.MemoryInfo.html

I am assuming that changing the comment in this file would eventually cause the change to be reflected in the API documentation.
