### PR TITLE
Correct example code

### DIFF
--- a/keystore/java/android/security/KeyPairGeneratorSpec.java
+++ b/keystore/java/android/security/KeyPairGeneratorSpec.java
@@ -315,7 +315,7 @@ public final class KeyPairGeneratorSpec implements AlgorithmParameterSpec {
      * <pre class="prettyprint">
      * Calendar start = new Calendar();
      * Calendar end = new Calendar();
-     * end.add(1, Calendar.YEAR);
+     * end.add(Calendar.YEAR, 1);
      *
      * KeyPairGeneratorSpec spec =
      *         new KeyPairGeneratorSpec.Builder(mContext).setAlias(&quot;myKey&quot;)


### PR DESCRIPTION
KeyPairGeneratorSpec.Builder's example code is functionally correct but semantically wrong: the arguments for Calendar.add(int,int) are reversed.

Building on this example code like 'add(1, Calendar.YEAR)' -> 'add(10, Calendar.YEAR)' in the obvious way will result in adding one hour, rather than ten years as expected.
