### PR TITLE
Stifle libpng warning in aapt

### DIFF
--- a/tools/aapt/Images.cpp
+++ b/tools/aapt/Images.cpp
@@ -106,6 +106,7 @@ static void read_png(const char* imageName,
 
     png_set_error_fn(read_ptr, const_cast<char*>(imageName),
             NULL /* use default errorfn */, log_warning);
+    png_set_option(read_ptr, PNG_SKIP_sRGB_CHECK_PROFILE, PNG_OPTION_ON);
     png_read_info(read_ptr, read_info);
 
     png_get_IHDR(read_ptr, read_info, &outImageInfo->width,


### PR DESCRIPTION
This one-line change to Images.cpp tells libpng to skip the sRGB check, using an option that was added in libpng 1.6.11.

Background:

libpng 1.6+ complains about an old sRGB profile that it not uncommon in png files, which can result in many lines of useless warnings in the gradle console.

See [Issue 77704](https://code.google.com/p/android/issues/detail?id=77704)
