### PR TITLE
fix wifi power calculator

### DIFF
--- a/core/java/com/android/internal/os/WifiPowerEstimator.java
+++ b/core/java/com/android/internal/os/WifiPowerEstimator.java
@@ -44,7 +44,7 @@ public class WifiPowerEstimator extends PowerCalculator {
         final long WIFI_BPS = 1000000; // TODO: Extract average bit rates from system
         final double WIFI_POWER = profile.getAveragePower(PowerProfile.POWER_WIFI_ACTIVE)
                 / 3600;
-        return (WIFI_POWER / (((double)WIFI_BPS) / 8 / 2048)) / (60*60);
+        return WIFI_POWER / (((double)WIFI_BPS) / 8 / 2048);
     }
 
     @Override


### PR DESCRIPTION
getWifiPowerPerPacket:  convert power mAh to mAs, only need divided by 3600 once, but result divided by 3600 twice.
WIFI_POWER (unit: mAs),  WIFI_BPS (unit: bit/s), so return result don't need divided by 60*60 again.
