### PR TITLE
Not to do handshake verification in SSLSocketFactory

### DIFF
--- a/core/java/android/net/SSLCertificateSocketFactory.java
+++ b/core/java/android/net/SSLCertificateSocketFactory.java
@@ -181,22 +181,18 @@ public class SSLCertificateSocketFactory extends SSLSocketFactory {
      *
      * @param socket An SSL socket which has been connected to a server
      * @param hostname The expected hostname of the remote server
-     * @throws IOException if something goes wrong handshaking with the server
      * @throws SSLPeerUnverifiedException if the server cannot prove its identity
+     * @throws SSLException if SSLSession not created (null)
      *
      * @hide
      */
-    public static void verifyHostname(Socket socket, String hostname) throws IOException {
+    public static void verifyHostname(Socket socket, String hostname) throws SSLException {
         if (!(socket instanceof SSLSocket)) {
             throw new IllegalArgumentException("Attempt to verify non-SSL socket");
         }
 
         if (!isSslCheckRelaxed()) {
-            // The code at the start of OpenSSLSocketImpl.startHandshake()
-            // ensures that the call is idempotent, so we can safely call it.
             SSLSocket ssl = (SSLSocket) socket;
-            ssl.startHandshake();
-
             SSLSession session = ssl.getSession();
             if (session == null) {
                 throw new SSLException("Cannot verify SSL socket without session");


### PR DESCRIPTION
Doing handshake without proper ssl settings will sometimes result in server's rejection of the handshake and thereby the connection.
Here is an example of this kind of problem: https://github.com/ParsePlatform/Parse-SDK-Android/issues/430
Basically the clients (examples listed in the end) of the SSLSocketFactory are going to do more handhshake settings before they call the handshake function of the SSLSocket created by SSLSocketFactory. The
SSLCertificateSocketFactory is doing redundant work on this, and more than that, it may lead to the socket's breaking.

Some of the clients of SSLSocketFactory that set SSLSocket before handshake:
https://android.googlesource.com/platform/libcore/+/09f1b0c/luni/src/main/java/libcore/net/http/HttpConnection.java#204
https://android.googlesource.com/platform/external/okhttp/+/android-5.1.1_r36/okhttp/src/main/java/com/squareup/okhttp/Connection.java#166
