### PR TITLE
Fixed getPixels stride parameter documentation

### DIFF
--- a/graphics/java/android/graphics/Bitmap.java
+++ b/graphics/java/android/graphics/Bitmap.java
@@ -1363,7 +1363,8 @@ public final class Bitmap implements Parcelable {
      * @param pixels   The array to receive the bitmap's colors
      * @param offset   The first index to write into pixels[]
      * @param stride   The number of entries in pixels[] to skip between
-     *                 rows (must be >= bitmap's width). Can be negative.
+     *                 rows (absolute value must be >= width parameter).
+     *                 Can be negative.
      * @param x        The x coordinate of the first pixel to read from
      *                 the bitmap
      * @param y        The y coordinate of the first pixel to read from


### PR DESCRIPTION
How can stride be >= than the bitmap width but at the same time negative?
Also it's not the width of the bitmap, but the given width parameter.
Check: https://code.google.com/p/android/issues/detail?id=54796
