### PR TITLE
isShowing() reports dialog as invisible following a call to hide().

### DIFF
--- a/core/java/android/app/Dialog.java
+++ b/core/java/android/app/Dialog.java
@@ -325,6 +325,7 @@ public class Dialog implements DialogInterface, Window.Callback,
     public void hide() {
         if (mDecor != null) {
             mDecor.setVisibility(View.GONE);
+            mShowing = false;
         }
     }
 


### PR DESCRIPTION
Fix to progressDialog.isShowing() reports dialog as visible even if hidden by progressDialog.hide()
See https://code.google.com/p/android/issues/detail?id=28910 for more info.
