### PR TITLE
remove context null check in constructor View(context)

### DIFF
--- a/core/java/android/view/View.java
+++ b/core/java/android/view/View.java
@@ -3987,7 +3987,7 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
      */
     public View(Context context) {
         mContext = context;
-        mResources = context != null ? context.getResources() : null;
+        mResources = context.getResources();
         mViewFlags = SOUND_EFFECTS_ENABLED | HAPTIC_FEEDBACK_ENABLED;
         // Set some flags defaults
         mPrivateFlags2 =


### PR DESCRIPTION
because the context is required not null by next invocation: 
mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();

so the null checking is no used at point: 
 mResources = context==null? context.getResources():null; 
