### PR TITLE
Support removal of Icon from preference

### DIFF
--- a/core/java/android/preference/Preference.java
+++ b/core/java/android/preference/Preference.java
@@ -708,7 +708,8 @@ public class Preference implements Comparable<Preference> {
     public void setIcon(@DrawableRes int iconResId) {
         if (mIconResId != iconResId) {
             mIconResId = iconResId;
-            setIcon(mContext.getDrawable(iconResId));
+            if (iconResId != 0)
+                setIcon(mContext.getDrawable(iconResId));
         }
     }
 


### PR DESCRIPTION
This is useful when a preference is used to select an icon (for instance), and the option of setting the selection BACK to 'none' is desired.
Due to logic at line 569, REMOVAL of an Icon from a preference that has one requires (mIconResId = 0) AND (mIcon = null).
(mIcon = null) is not a problem.
This change allows mIconResId to be set to zero. Without this modification, attempting to set (mIconResId = 0) throws an exception on the getDrawable(iconResId) call at line 711 (712 with this mod).
