### PR TITLE
Update TvInputManagerService.java

### DIFF
--- a/services/core/java/com/android/server/tv/TvInputManagerService.java
+++ b/services/core/java/com/android/server/tv/TvInputManagerService.java
@@ -2833,4 +2833,9 @@ public final class TvInputManagerService extends SystemService {
             super(name);
         }
     }
+    
+    @Override
+    public void onSwitchUser(int userHandle) {
+        switchUser(userHandle);
+    }
 }


### PR DESCRIPTION
When switching users, TvInputManagerService through Intent.ACTION_USER_SWITCHED broadcast to create new user information (userstate, etc.)
If there are other broadcasts in the broadcast queue, the TvInputManagerService will receive the broadcast for a slower time.
Google launcher has a problem if you access the new user's data before the TvInputManagerService receives the broadcast