### PR TITLE
SyncInfo: Remove @hide from Parcelable-related code

### DIFF
--- a/core/java/android/content/SyncInfo.java
+++ b/core/java/android/content/SyncInfo.java
@@ -78,12 +78,10 @@ public class SyncInfo implements Parcelable {
         this.startTime = other.startTime;
     }
 
-    /** @hide */
     public int describeContents() {
         return 0;
     }
 
-    /** @hide */
     public void writeToParcel(Parcel parcel, int flags) {
         parcel.writeInt(authorityId);
         parcel.writeParcelable(account, flags);
@@ -99,7 +97,6 @@ public class SyncInfo implements Parcelable {
         startTime = parcel.readLong();
     }
 
-    /** @hide */
     public static final Creator<SyncInfo> CREATOR = new Creator<SyncInfo>() {
         public SyncInfo createFromParcel(Parcel in) {
             return new SyncInfo(in);


### PR DESCRIPTION
`describeContents`, `writeToParcel` and `CREATOR` must be visible in order to use SyncInfo as a Parcelable.

In particular, with those methods hidden, it's impossible to use SyncInfo in non-Android AIDL files.