### PR TITLE
Removing unused code

### DIFF
--- a/core/java/android/app/PendingIntent.java
+++ b/core/java/android/app/PendingIntent.java
@@ -597,8 +597,8 @@ public final class PendingIntent implements Parcelable {
     public static PendingIntent getService(Context context, int requestCode,
             @NonNull Intent intent, @Flags int flags) {
         String packageName = context.getPackageName();
-        String resolvedType = intent != null ? intent.resolveTypeIfNeeded(
-                context.getContentResolver()) : null;
+        String resolvedType = intent.resolveTypeIfNeeded(
+                context.getContentResolver()) ;
         try {
             intent.prepareToLeaveProcess(context);
             IIntentSender target =


### PR DESCRIPTION
This function requires intent not to be null because we do
`intent.prepareToLeaveProcess(context);`
Then, no need to check for intent to be null here:
`String resolvedType = intent != null ? intent.resolveTypeIfNeeded(context.getContentResolver()) : null;`