### PR TITLE
Fix for null pointer exception

### DIFF
--- a/core/java/android/widget/PopupWindow.java
+++ b/core/java/android/widget/PopupWindow.java
@@ -2377,7 +2377,9 @@ public class PopupWindow {
 
                     // The listener was called. Our job here is done.
                     mPendingExitListener = null;
-                    t.removeListener(this);
+                    if(t!= null){
+                         t.removeListener(this);
+                    }
                 }
             };
 


### PR DESCRIPTION
On Google Pixel Devices it's causing null pointer exception when popup is shown.