### PR TITLE
Range checks in SparseArrays

### DIFF
--- a/core/java/android/util/LongSparseArray.java
+++ b/core/java/android/util/LongSparseArray.java
@@ -144,6 +144,10 @@ public class LongSparseArray<E> implements Cloneable {
      * Removes the mapping at the specified index.
      */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         if (mValues[index] != DELETED) {
             mValues[index] = DELETED;
             mGarbage = true;
@@ -236,6 +240,10 @@ public class LongSparseArray<E> implements Cloneable {
         if (mGarbage) {
             gc();
         }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
 
         return mKeys[index];
     }
@@ -256,6 +264,10 @@ public class LongSparseArray<E> implements Cloneable {
         if (mGarbage) {
             gc();
         }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
 
         return (E) mValues[index];
     }
@@ -268,6 +280,10 @@ public class LongSparseArray<E> implements Cloneable {
     public void setValueAt(int index, E value) {
         if (mGarbage) {
             gc();
+        }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
         }
 
         mValues[index] = value;

--- a/core/java/android/util/LongSparseLongArray.java
+++ b/core/java/android/util/LongSparseLongArray.java
@@ -124,6 +124,10 @@ public class LongSparseLongArray implements Cloneable {
      * Removes the mapping at the given index.
      */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         System.arraycopy(mKeys, index + 1, mKeys, index, mSize - (index + 1));
         System.arraycopy(mValues, index + 1, mValues, index, mSize - (index + 1));
         mSize--;
@@ -167,6 +171,10 @@ public class LongSparseLongArray implements Cloneable {
      * key.</p>
      */
     public long keyAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mKeys[index];
     }
 
@@ -182,7 +190,22 @@ public class LongSparseLongArray implements Cloneable {
      * associated with the largest key.</p>
      */
     public long valueAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mValues[index];
+    }
+    
+    /**
+     * Sets the value at the given {@code index}.
+     */
+    public void setValueAt(int index, long value) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
+        mValues[index] = value;
     }
 
     /**

--- a/core/java/android/util/SparseArray.java
+++ b/core/java/android/util/SparseArray.java
@@ -161,10 +161,14 @@ public class SparseArray<E> implements Cloneable {
     /**
      * Removes the mapping at the specified index.
      *
-     * <p>For indices outside of the range <code>0...size()-1</code>,
-     * the behavior is undefined.</p>
+     * <p>{@code index} must be in range <code>0...size()-1</code>,
+     * an exception will be thrown otherwise.</p>
      */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         if (mValues[index] != DELETED) {
             mValues[index] = DELETED;
             mGarbage = true;
@@ -177,8 +181,9 @@ public class SparseArray<E> implements Cloneable {
      * @param index Index to begin at
      * @param size Number of mappings to remove
      *
-     * <p>For indices outside of the range <code>0...size()-1</code>,
-     * the behavior is undefined.</p>
+     * <p><code>index...index+size-1</code> subrange
+     * must be in range <code>0...size()-1</code>,
+     * an exception will be thrown otherwise.</p>
      */
     public void removeAtRange(int index, int size) {
         final int end = Math.min(mSize, index + size);
@@ -269,12 +274,16 @@ public class SparseArray<E> implements Cloneable {
      * smallest key and <code>keyAt(size()-1)</code> will return the largest
      * key.</p>
      *
-     * <p>For indices outside of the range <code>0...size()-1</code>,
-     * the behavior is undefined.</p>
+     * <p>{@code index} must be in range <code>0...size()-1</code>,
+     * an exception will be thrown otherwise.</p>
      */
     public int keyAt(int index) {
         if (mGarbage) {
             gc();
+        }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
         }
 
         return mKeys[index];
@@ -291,13 +300,17 @@ public class SparseArray<E> implements Cloneable {
      * smallest key and <code>valueAt(size()-1)</code> will return the value
      * associated with the largest key.</p>
      *
-     * <p>For indices outside of the range <code>0...size()-1</code>,
-     * the behavior is undefined.</p>
+     * <p>{@code index} must be in range <code>0...size()-1</code>,
+     * an exception will be thrown otherwise.</p>
      */
     @SuppressWarnings("unchecked")
     public E valueAt(int index) {
         if (mGarbage) {
             gc();
+        }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
         }
 
         return (E) mValues[index];
@@ -308,11 +321,16 @@ public class SparseArray<E> implements Cloneable {
      * value for the <code>index</code>th key-value mapping that this
      * SparseArray stores.
      *
-     * <p>For indices outside of the range <code>0...size()-1</code>, the behavior is undefined.</p>
+     * <p>{@code index} must be in range <code>0...size()-1</code>,
+     * an exception will be thrown otherwise.</p>
      */
     public void setValueAt(int index, E value) {
         if (mGarbage) {
             gc();
+        }
+        
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
         }
 
         mValues[index] = value;

--- a/core/java/android/util/SparseBooleanArray.java
+++ b/core/java/android/util/SparseBooleanArray.java
@@ -119,6 +119,10 @@ public class SparseBooleanArray implements Cloneable {
 
     /** @hide */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         System.arraycopy(mKeys, index + 1, mKeys, index, mSize - (index + 1));
         System.arraycopy(mValues, index + 1, mValues, index, mSize - (index + 1));
         mSize--;
@@ -162,6 +166,10 @@ public class SparseBooleanArray implements Cloneable {
      * key.</p>
      */
     public int keyAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mKeys[index];
     }
 
@@ -177,16 +185,28 @@ public class SparseBooleanArray implements Cloneable {
      * associated with the largest key.</p>
      */
     public boolean valueAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mValues[index];
     }
 
     /** @hide */
     public void setValueAt(int index, boolean value) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         mValues[index] = value;
     }
 
     /** @hide */
     public void setKeyAt(int index, int key) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         mKeys[index] = key;
     }
 

--- a/core/java/android/util/SparseIntArray.java
+++ b/core/java/android/util/SparseIntArray.java
@@ -124,6 +124,10 @@ public class SparseIntArray implements Cloneable {
      * Removes the mapping at the given index.
      */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         System.arraycopy(mKeys, index + 1, mKeys, index, mSize - (index + 1));
         System.arraycopy(mValues, index + 1, mValues, index, mSize - (index + 1));
         mSize--;
@@ -167,6 +171,10 @@ public class SparseIntArray implements Cloneable {
      * key.</p>
      */
     public int keyAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mKeys[index];
     }
 
@@ -182,6 +190,10 @@ public class SparseIntArray implements Cloneable {
      * associated with the largest key.</p>
      */
     public int valueAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mValues[index];
     }
 
@@ -190,6 +202,10 @@ public class SparseIntArray implements Cloneable {
      * @hide
      */
     public void setValueAt(int index, int value) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         mValues[index] = value;
     }
 

--- a/core/java/android/util/SparseLongArray.java
+++ b/core/java/android/util/SparseLongArray.java
@@ -122,6 +122,10 @@ public class SparseLongArray implements Cloneable {
      * Removes the mapping at the given index.
      */
     public void removeAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         System.arraycopy(mKeys, index + 1, mKeys, index, mSize - (index + 1));
         System.arraycopy(mValues, index + 1, mValues, index, mSize - (index + 1));
         mSize--;
@@ -165,6 +169,10 @@ public class SparseLongArray implements Cloneable {
      * key.</p>
      */
     public int keyAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mKeys[index];
     }
 
@@ -180,7 +188,22 @@ public class SparseLongArray implements Cloneable {
      * associated with the largest key.</p>
      */
     public long valueAt(int index) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
         return mValues[index];
+    }
+    
+    /**
+     * Sets the {@code value} at the given {@code index}.
+     */
+    public void setValueAt(int index, long value) {
+        if (index >= mSize) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        
+        mValues[index] = value;
     }
 
     /**


### PR DESCRIPTION
At the moment, `keyAt`, `valueAt`, `removeAt` and `setValueAt` methods are performing no range checks. This is great for performance, but exposes unused tail of array: if one passes an index from range `[mSize .. mKeys.length)` to such method, unexpected result will be returned.

```
typical SparseArray
keys:    1    3    7    9    0    0    0    0    0    0
values:  a    b    c    d    null null null null null null
indices: 0    1    2    3    4    5    6    7    8    9
                             ^ size                        ^ length
```

Added range checks into `SparseArray`, `LongSparseArray`, `LongSparseLongArray`, `SparseBooleanArray`, `SparseIntArray`, `SparseLongArray`. Throwing `ArrayIndexOutOfBoundsException` for consistency (because VM throws it for indices, which are < 0).

As a bonus, added `setValueAt` methods into `LongSparseLongArray` and `SparseLongArray`.