### PR TITLE
add missing @Deprecated annotation to such methods that have documentation indicating they are deprecated

### DIFF
--- a/core/java/android/accessibilityservice/AccessibilityServiceInfo.java
+++ b/core/java/android/accessibilityservice/AccessibilityServiceInfo.java
@@ -626,6 +626,7 @@ public class AccessibilityServiceInfo implements Parcelable {
      *
      * @deprecated Use {@link #getCapabilities()}.
      */
+    @Deprecated
     public boolean getCanRetrieveWindowContent() {
         return (mCapabilities & CAPABILITY_CAN_RETRIEVE_WINDOW_CONTENT) != 0;
     }
@@ -696,6 +697,7 @@ public class AccessibilityServiceInfo implements Parcelable {
      *
      * @deprecated Use {@link #loadDescription(PackageManager)}.
      */
+    @Deprecated
     public String getDescription() {
         return mNonLocalizedDescription;
     }

--- a/core/java/android/app/ActivityManagerNative.java
+++ b/core/java/android/app/ActivityManagerNative.java
@@ -30,6 +30,7 @@ public abstract class ActivityManagerNative {
      *
      * @deprecated use IActivityManager.Stub.asInterface instead.
      */
+    @Deprecated
     static public IActivityManager asInterface(IBinder obj) {
         return IActivityManager.Stub.asInterface(obj);
     }
@@ -39,6 +40,7 @@ public abstract class ActivityManagerNative {
      *
      * @deprecated use ActivityManager.getService instead.
      */
+    @Deprecated
     static public IActivityManager getDefault() {
         return ActivityManager.getService();
     }
@@ -48,6 +50,7 @@ public abstract class ActivityManagerNative {
      *
      * @deprecated use ActivityManagerInternal.isSystemReady instead.
      */
+    @Deprecated
     static public boolean isSystemReady() {
         return ActivityManager.isSystemReady();
     }
@@ -55,6 +58,7 @@ public abstract class ActivityManagerNative {
     /**
      * @deprecated use ActivityManager.broadcastStickyIntent instead.
      */
+    @Deprecated
     static public void broadcastStickyIntent(Intent intent, String permission, int userId) {
         broadcastStickyIntent(intent, permission, AppOpsManager.OP_NONE, userId);
     }
@@ -65,6 +69,7 @@ public abstract class ActivityManagerNative {
      *
      * @deprecated use ActivityManager.broadcastStickyIntent instead.
      */
+    @Deprecated
     static public void broadcastStickyIntent(Intent intent, String permission, int appOp,
             int userId) {
         ActivityManager.broadcastStickyIntent(intent, appOp, userId);
@@ -73,6 +78,7 @@ public abstract class ActivityManagerNative {
     /**
      * @deprecated use ActivityManager.noteWakeupAlarm instead.
      */
+    @Deprecated
     static public void noteWakeupAlarm(PendingIntent ps, int sourceUid, String sourcePkg,
             String tag) {
         ActivityManager.noteWakeupAlarm(ps, sourceUid, sourcePkg, tag);
@@ -81,6 +87,7 @@ public abstract class ActivityManagerNative {
     /**
      * @deprecated use ActivityManager.noteAlarmStart instead.
      */
+    @Deprecated
     static public void noteAlarmStart(PendingIntent ps, int sourceUid, String tag) {
         ActivityManager.noteAlarmStart(ps, sourceUid, tag);
     }
@@ -88,6 +95,7 @@ public abstract class ActivityManagerNative {
     /**
      * @deprecated use ActivityManager.noteAlarmFinish instead.
      */
+    @Deprecated
     static public void noteAlarmFinish(PendingIntent ps, int sourceUid, String tag) {
         ActivityManager.noteAlarmFinish(ps, sourceUid, tag);
     }

--- a/core/java/android/service/persistentdata/PersistentDataBlockManager.java
+++ b/core/java/android/service/persistentdata/PersistentDataBlockManager.java
@@ -159,6 +159,7 @@ public class PersistentDataBlockManager {
      * @deprecated use {@link OemLockManager#setOemUnlockAllowedByUser(boolean)} instead.
      */
     @RequiresPermission(android.Manifest.permission.OEM_UNLOCK_STATE)
+    @Deprecated
     public void setOemUnlockEnabled(boolean enabled) {
         try {
             sService.setOemUnlockEnabled(enabled);
@@ -176,6 +177,7 @@ public class PersistentDataBlockManager {
             android.Manifest.permission.READ_OEM_UNLOCK_STATE,
             android.Manifest.permission.OEM_UNLOCK_STATE
     })
+    @Deprecated
     public boolean getOemUnlockEnabled() {
         try {
             return sService.getOemUnlockEnabled();

--- a/core/java/android/webkit/Plugin.java
+++ b/core/java/android/webkit/Plugin.java
@@ -43,6 +43,7 @@ public class Plugin {
          * @deprecated This interface was intended to be used by Gears. Since Gears was
          * deprecated, so is this class.
          */
+    @Deprecated
         public void handleClickEvent(Context context);
     }
 

--- a/core/java/com/android/internal/widget/PagerAdapter.java
+++ b/core/java/com/android/internal/widget/PagerAdapter.java
@@ -155,6 +155,7 @@ public abstract class PagerAdapter {
      *
      * @deprecated Use {@link #startUpdate(android.view.ViewGroup)}
      */
+    @Deprecated
     public void startUpdate(View container) {
     }
 
@@ -171,6 +172,7 @@ public abstract class PagerAdapter {
      *
      * @deprecated Use {@link #instantiateItem(android.view.ViewGroup, int)}
      */
+    @Deprecated
     public Object instantiateItem(View container, int position) {
         throw new UnsupportedOperationException(
                 "Required method instantiateItem was not overridden");
@@ -188,6 +190,7 @@ public abstract class PagerAdapter {
      *
      * @deprecated Use {@link #destroyItem(android.view.ViewGroup, int, Object)}
      */
+    @Deprecated
     public void destroyItem(View container, int position, Object object) {
         throw new UnsupportedOperationException("Required method destroyItem was not overridden");
     }
@@ -203,6 +206,7 @@ public abstract class PagerAdapter {
      *
      * @deprecated Use {@link #setPrimaryItem(android.view.ViewGroup, int, Object)}
      */
+    @Deprecated
     public void setPrimaryItem(View container, int position, Object object) {
     }
 
@@ -215,6 +219,7 @@ public abstract class PagerAdapter {
      *
      * @deprecated Use {@link #finishUpdate(android.view.ViewGroup)}
      */
+    @Deprecated
     public void finishUpdate(View container) {
     }
 

--- a/drm/java/android/drm/DrmSupportInfo.java
+++ b/drm/java/android/drm/DrmSupportInfo.java
@@ -108,6 +108,7 @@ public class DrmSupportInfo {
      * @deprecated The method name is mis-spelled, and it is replaced by
      * {@link #getDescription()}.
      */
+    @Deprecated
     public String getDescriprition() {
         return mDescription;
     }
@@ -185,4 +186,3 @@ public class DrmSupportInfo {
         return mFileSuffixList.contains(fileSuffix);
     }
 }
-

--- a/graphics/java/android/graphics/BitmapFactory.java
+++ b/graphics/java/android/graphics/BitmapFactory.java
@@ -426,6 +426,7 @@ public class BitmapFactory {
          *  or if inJustDecodeBounds is true, will set outWidth/outHeight
          *  to -1
          */
+    @Deprecated
         public void requestCancelDecode() {
             mCancel = true;
         }

--- a/graphics/java/android/graphics/Canvas.java
+++ b/graphics/java/android/graphics/Canvas.java
@@ -403,6 +403,7 @@ public class Canvas extends BaseCanvas {
      *                  to save/restore
      * @return The value to pass to restoreToCount() to balance this save()
      */
+    @Deprecated
     public int save(@Saveflags int saveFlags) {
         return nSave(mNativeCanvasWrapper, saveFlags);
     }
@@ -438,6 +439,7 @@ public class Canvas extends BaseCanvas {
      *               for performance reasons.
      * @return       value to pass to restoreToCount() to balance this save()
      */
+    @Deprecated
     public int saveLayer(@Nullable RectF bounds, @Nullable Paint paint, @Saveflags int saveFlags) {
         if (bounds == null) {
             bounds = new RectF(getClipBounds());
@@ -480,6 +482,7 @@ public class Canvas extends BaseCanvas {
      *
      * @deprecated Use {@link #saveLayer(float, float, float, float, Paint)} instead.
      */
+    @Deprecated
     public int saveLayer(float left, float top, float right, float bottom, @Nullable Paint paint,
             @Saveflags int saveFlags) {
         return nSaveLayer(mNativeCanvasWrapper, left, top, right, bottom,
@@ -524,6 +527,7 @@ public class Canvas extends BaseCanvas {
      *                  for performance reasons.
      * @return          value to pass to restoreToCount() to balance this call
      */
+    @Deprecated
     public int saveLayerAlpha(@Nullable RectF bounds, int alpha, @Saveflags int saveFlags) {
         if (bounds == null) {
             bounds = new RectF(getClipBounds());
@@ -549,6 +553,7 @@ public class Canvas extends BaseCanvas {
      *
      * @deprecated Use {@link #saveLayerAlpha(float, float, float, float, int)} instead.
      */
+    @Deprecated
     public int saveLayerAlpha(float left, float top, float right, float bottom, int alpha,
             @Saveflags int saveFlags) {
         alpha = Math.min(255, Math.max(0, alpha));

--- a/media/java/android/media/MediaCodecList.java
+++ b/media/java/android/media/MediaCodecList.java
@@ -39,6 +39,7 @@ final public class MediaCodecList {
      *
      * @see #REGULAR_CODECS
      */
+    @Deprecated
     public static final int getCodecCount() {
         initCodecList();
         return sRegularCodecInfos.length;

--- a/packages/SystemUI/plugin/src/com/android/systemui/plugins/Plugin.java
+++ b/packages/SystemUI/plugin/src/com/android/systemui/plugins/Plugin.java
@@ -116,6 +116,7 @@ public interface Plugin {
      * @deprecated
      * @see Requires
      */
+    @Deprecated
     default int getVersion() {
         // Default of -1 indicates the plugin supports the new Requires model.
         return -1;

--- a/rs/java/android/renderscript/FileA3D.java
+++ b/rs/java/android/renderscript/FileA3D.java
@@ -89,6 +89,7 @@ public class FileA3D extends BaseObj {
         * describes
         *
         */
+    @Deprecated
         public String getName() {
             return mName;
         }
@@ -100,6 +101,7 @@ public class FileA3D extends BaseObj {
         * @return type of a renderscript object the index entry
         *         describes
         */
+    @Deprecated
         public EntryType getEntryType() {
             return mEntryType;
         }
@@ -109,6 +111,7 @@ public class FileA3D extends BaseObj {
         * Used to load the object described by the index entry
         * @return base renderscript object described by the entry
         */
+    @Deprecated
         public BaseObj getObject() {
             mRS.validate();
             BaseObj obj = internalCreate(mRS, this);
@@ -122,6 +125,7 @@ public class FileA3D extends BaseObj {
         *
         * @return renderscript mesh object described by the entry
         */
+        @Deprecated
         public Mesh getMesh() {
             return (Mesh)getObject();
         }

--- a/telecomm/java/android/telecom/RemoteConnection.java
+++ b/telecomm/java/android/telecom/RemoteConnection.java
@@ -1065,7 +1065,7 @@ public final class RemoteConnection {
      *
      * @param state The audio state of this {@code RemoteConnection}.
      * @hide
-     * @deprecated Use {@link #setCallAudioState(CallAudioState) instead.
+     * @deprecated Use {@link #setCallAudioState(CallAudioState)} instead.
      */
     @SystemApi
     @Deprecated

--- a/telecomm/java/android/telecom/TelecomManager.java
+++ b/telecomm/java/android/telecom/TelecomManager.java
@@ -999,6 +999,7 @@ public class TelecomManager {
      */
     @SystemApi
     @SuppressLint("Doclava125")
+    @Deprecated
     public void clearAccounts() {
         try {
             if (isServiceConnected()) {
@@ -1031,6 +1032,7 @@ public class TelecomManager {
      */
     @SystemApi
     @SuppressLint("Doclava125")
+    @Deprecated
     public ComponentName getDefaultPhoneApp() {
         try {
             if (isServiceConnected()) {

--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -188,6 +188,7 @@ public class TelephonyManager {
 
     /** @hide
     /* @deprecated - use getSystemService as described above */
+    @Deprecated
     public static TelephonyManager getDefault() {
         return sInstance;
     }


### PR DESCRIPTION
There are some methods that are marked as deprecated in their Javadoc but are not explicitly annotated (with @Deprecated annotation).
This pull request adds the missing @Deprecated annotation to those methods.