### PR TITLE
Real override of onShareTargetSelectedListener

### DIFF
--- a/core/java/android/widget/ShareActionProvider.java
+++ b/core/java/android/widget/ShareActionProvider.java
@@ -333,7 +333,7 @@ public class ShareActionProvider extends ActionProvider {
         @Override
         public boolean onChooseActivity(ActivityChooserModel host, Intent intent) {
             if (mOnShareTargetSelectedListener != null) {
-                mOnShareTargetSelectedListener.onShareTargetSelected(
+                return mOnShareTargetSelectedListener.onShareTargetSelected(
                         ShareActionProvider.this, intent);
             }
             return false;


### PR DESCRIPTION
That way, the override of OnShareTargetSelectedListener can refuse to lauch the regular share action and do something else instead by return true.