### PR TITLE
fix NPE. switch-case wasn't wrapped with (f != null), and we has invoked method from null fragment

### DIFF
--- a/core/java/android/app/BackStackRecord.java
+++ b/core/java/android/app/BackStackRecord.java
@@ -822,43 +822,43 @@ final class BackStackRecord extends FragmentTransaction implements
             if (f != null) {
                 f.setNextTransition(FragmentManagerImpl.reverseTransit(mTransition),
                         mTransitionStyle);
-            }
-            switch (op.cmd) {
-                case OP_ADD:
-                    f.setNextAnim(op.popExitAnim);
-                    mManager.removeFragment(f);
-                    break;
-                case OP_REMOVE:
-                    f.setNextAnim(op.popEnterAnim);
-                    mManager.addFragment(f, false);
-                    break;
-                case OP_HIDE:
-                    f.setNextAnim(op.popEnterAnim);
-                    mManager.showFragment(f);
-                    break;
-                case OP_SHOW:
-                    f.setNextAnim(op.popExitAnim);
-                    mManager.hideFragment(f);
-                    break;
-                case OP_DETACH:
-                    f.setNextAnim(op.popEnterAnim);
-                    mManager.attachFragment(f);
-                    break;
-                case OP_ATTACH:
-                    f.setNextAnim(op.popExitAnim);
-                    mManager.detachFragment(f);
-                    break;
-                case OP_SET_PRIMARY_NAV:
-                    mManager.setPrimaryNavigationFragment(null);
-                    break;
-                case OP_UNSET_PRIMARY_NAV:
-                    mManager.setPrimaryNavigationFragment(f);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown cmd: " + op.cmd);
-            }
-            if (!mReorderingAllowed && op.cmd != OP_REMOVE && f != null) {
-                mManager.moveFragmentToExpectedState(f);
+                switch (op.cmd) {
+                    case OP_ADD:
+                        f.setNextAnim(op.popExitAnim);
+                        mManager.removeFragment(f);
+                        break;
+                    case OP_REMOVE:
+                        f.setNextAnim(op.popEnterAnim);
+                        mManager.addFragment(f, false);
+                        break;
+                    case OP_HIDE:
+                        f.setNextAnim(op.popEnterAnim);
+                        mManager.showFragment(f);
+                        break;
+                    case OP_SHOW:
+                        f.setNextAnim(op.popExitAnim);
+                        mManager.hideFragment(f);
+                        break;
+                    case OP_DETACH:
+                        f.setNextAnim(op.popEnterAnim);
+                        mManager.attachFragment(f);
+                        break;
+                    case OP_ATTACH:
+                        f.setNextAnim(op.popExitAnim);
+                        mManager.detachFragment(f);
+                        break;
+                    case OP_SET_PRIMARY_NAV:
+                        mManager.setPrimaryNavigationFragment(null);
+                        break;
+                    case OP_UNSET_PRIMARY_NAV:
+                        mManager.setPrimaryNavigationFragment(f);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown cmd: " + op.cmd);
+                }
+                if (!mReorderingAllowed && op.cmd != OP_REMOVE) {
+                    mManager.moveFragmentToExpectedState(f);
+                }
             }
         }
         if (!mReorderingAllowed && moveToState) {

--- a/core/java/android/app/BackStackRecord.java
+++ b/core/java/android/app/BackStackRecord.java
@@ -763,43 +763,43 @@ final class BackStackRecord extends FragmentTransaction implements
             final Fragment f = op.fragment;
             if (f != null) {
                 f.setNextTransition(mTransition, mTransitionStyle);
-            }
-            switch (op.cmd) {
-                case OP_ADD:
-                    f.setNextAnim(op.enterAnim);
-                    mManager.addFragment(f, false);
-                    break;
-                case OP_REMOVE:
-                    f.setNextAnim(op.exitAnim);
-                    mManager.removeFragment(f);
-                    break;
-                case OP_HIDE:
-                    f.setNextAnim(op.exitAnim);
-                    mManager.hideFragment(f);
-                    break;
-                case OP_SHOW:
-                    f.setNextAnim(op.enterAnim);
-                    mManager.showFragment(f);
-                    break;
-                case OP_DETACH:
-                    f.setNextAnim(op.exitAnim);
-                    mManager.detachFragment(f);
-                    break;
-                case OP_ATTACH:
-                    f.setNextAnim(op.enterAnim);
-                    mManager.attachFragment(f);
-                    break;
-                case OP_SET_PRIMARY_NAV:
-                    mManager.setPrimaryNavigationFragment(f);
-                    break;
-                case OP_UNSET_PRIMARY_NAV:
-                    mManager.setPrimaryNavigationFragment(null);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unknown cmd: " + op.cmd);
-            }
-            if (!mReorderingAllowed && op.cmd != OP_ADD && f != null) {
-                mManager.moveFragmentToExpectedState(f);
+                switch (op.cmd) {
+                    case OP_ADD:
+                        f.setNextAnim(op.enterAnim);
+                        mManager.addFragment(f, false);
+                        break;
+                    case OP_REMOVE:
+                        f.setNextAnim(op.exitAnim);
+                        mManager.removeFragment(f);
+                        break;
+                    case OP_HIDE:
+                        f.setNextAnim(op.exitAnim);
+                        mManager.hideFragment(f);
+                        break;
+                    case OP_SHOW:
+                        f.setNextAnim(op.enterAnim);
+                        mManager.showFragment(f);
+                        break;
+                    case OP_DETACH:
+                        f.setNextAnim(op.exitAnim);
+                        mManager.detachFragment(f);
+                        break;
+                    case OP_ATTACH:
+                        f.setNextAnim(op.enterAnim);
+                        mManager.attachFragment(f);
+                        break;
+                    case OP_SET_PRIMARY_NAV:
+                        mManager.setPrimaryNavigationFragment(f);
+                        break;
+                    case OP_UNSET_PRIMARY_NAV:
+                        mManager.setPrimaryNavigationFragment(null);
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unknown cmd: " + op.cmd);
+                }
+                if (!mReorderingAllowed && op.cmd != OP_ADD) {
+                    mManager.moveFragmentToExpectedState(f);
+                }
             }
         }
         if (!mReorderingAllowed) {


### PR DESCRIPTION
I am sure that I put non null fragment in transaction, because it is checked two times for null, but still I am getting NPE in BackStackRecord.executeOps() method. This method also contains null check (f != null), but still invokes Fragment.setNextAnim(int) on null object.