### PR TITLE
Canvas in onDraw() nullable

### DIFF
--- a/core/java/android/view/View.java
+++ b/core/java/android/view/View.java
@@ -20764,7 +20764,7 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
      *
      * @param canvas the canvas on which the background will be drawn
      */
-    protected void onDraw(Canvas canvas) {
+    protected void onDraw(@Nullable Canvas canvas) {
     }
 
     /*


### PR DESCRIPTION
i think that usage of kotlin bring confusion either one 
`onDraw(canvas: Canvas)` 
or
`onDraw(canvas: Canvas?)`

how about change it nullable
or process NPE for non-null type 